### PR TITLE
fix the big integer raising issue when doing fund action

### DIFF
--- a/src/currencies/matic.ts
+++ b/src/currencies/matic.ts
@@ -68,7 +68,13 @@ export async function createMaticTx({ amount, to }: CreateTxData, key: Buffer): 
 
     await provider._ready();
     const wallet = new Wallet(key, provider);
-    const _amount = ethers.utils.hexlify(BigNumber.isBigNumber(amount) ? "0x" + amount.toString(16) : amount);
+    let bigNumberAmount: BigNumber;
+    if (BigNumber.isBigNumber(amount)) {
+        bigNumberAmount = amount
+    } else {
+        bigNumberAmount =  new BigNumber(amount)
+    }
+    const _amount = "0x" + bigNumberAmount.toString(16);
 
     const estimatedGas = await provider.estimateGas({ to, value: _amount });
     const gasPrice = await provider.getGasPrice();


### PR DESCRIPTION
Currently when doing the fund action on ploygon it will raise issue when the number is big than 9007199254740991(2**53 -1), it is because `ethers.utils.hexlify` function will check the number and if this is not a safe js integer, it will raise the issue.

However since the decimal of MATIC is 18, it will really easy the number is bigger than 2 **53. This PR is to fix the issue by using the bignumber  instead of javascript number.